### PR TITLE
rename slice to store

### DIFF
--- a/src/connect.ls
+++ b/src/connect.ls
@@ -9,17 +9,17 @@ module.exports = ({component, map-props}) ->
   class Connector extends react.Component
 
     @context-types =
-      slice: react.PropTypes.any
+      store: react.PropTypes.any
 
 
     (props, context) ->
       super props, context
-      @state = map-props @context.slice
-      @context.slice.$on-update @update
+      @state = map-props @context.store
+      @context.store.$on-update @update
 
 
     componentWillUnmount: ->
-      @context.slice.$off-update @update
+      @context.store.$off-update @update
 
 
     render: ->
@@ -27,4 +27,4 @@ module.exports = ({component, map-props}) ->
 
 
     update: ~>
-      @setState map-props @context.slice
+      @setState map-props @context.store

--- a/src/connect.spec.ls
+++ b/src/connect.spec.ls
@@ -17,16 +17,16 @@ describe 'connect' ->
   beforeEach ->
     @connectedHoc = connect do
       component: TestComponent
-      map-props: (slice) -> {name: slice.name.$get!}
+      map-props: (store) -> {name: store.name.$get!}
 
   specify 'defines a component with a required context type for slice', ->
-    expect(@connectedHoc.context-types.slice).to.exist
+    expect(@connectedHoc.context-types.store).to.exist
 
   describe 'rendering', ->
     before-each ->
       @slice = new Slice {schema}, []
       component = react.create-element @connectedHoc, {other: 'data'}
-      @wrapper = shallow component, context: {@slice}
+      @wrapper = shallow component, context: {store: @slice}
 
     specify 'renders the component with the passed in props and the result of map-props', ->
       expect(@wrapper.is('TestComponent')).to.be.true

--- a/src/provider.ls
+++ b/src/provider.ls
@@ -3,16 +3,16 @@ require! {
 }
 
 
-module.exports = ({component, slice}) ->
+module.exports = ({component, store}) ->
 
   class Provider extends react.Component
 
     @child-context-types =
-      slice: react.PropTypes.any
+      store: react.PropTypes.any
 
 
     get-child-context: ->
-      {slice}
+      {store}
 
 
     render: ->

--- a/src/provider.spec.ls
+++ b/src/provider.spec.ls
@@ -11,18 +11,18 @@ class TestComponent extends react.Component
 describe 'Provider' ->
 
   beforeEach ->
-    @slice = mock: 'slice data'
-    @providerHoc = Provider {component: TestComponent, @slice}
+    @store = mock: 'slice data'
+    @providerHoc = Provider {component: TestComponent, @store}
 
-  specify 'defines a child context type for slice', ->
-    expect(@providerHoc.child-context-types.slice).to.exist
+  specify 'defines a child context type for store', ->
+    expect(@providerHoc.child-context-types.store).to.exist
 
   describe 'rendering', ->
     beforeEach ->
       @wrapper = shallow react.create-element @providerHoc, {}
 
-    specify 'defines a child context with the slice', ->
-      expect(@wrapper.instance().get-child-context()).to.eql {@slice}
+    specify 'defines a child context with the store', ->
+      expect(@wrapper.instance().get-child-context()).to.eql {@store}
 
     specify 'renders the component', ->
       expect(@wrapper.is('TestComponent')).to.be.true


### PR DESCRIPTION
just for top level methods. A slice is a portion of the store but I feel you will typically combine slices to make a store. Open to other names or just rejecting this. In writing the readme, I thought having slice as the top level seemed odd.