### PR TITLE
fix publish process

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "scripts": {
     "build": "webpack",
-    "prepblish": "npm run build",
+    "prepublish": "npm run build",
     "test": "mocha 'src/**/*.spec.ls'"
   },
   "license": "MIT",


### PR DESCRIPTION
resolves #17

The current published version does not have a `index.js` file. Ensure its always there by making build a prepublish step. Add files in order for the development files to be removed.