### PR TITLE
generalize map

### DIFF
--- a/docs/api/map_methods.md
+++ b/docs/api/map_methods.md
@@ -1,18 +1,15 @@
 # Map Methods
 
-Map placeholders will create objects which have the following methods:
+Map placeholders will create objects which are very similar to [Trees / Leafs](./tree_leaf_methods.md).
+The `$fromPromise`, `$set`, `$setError`, and `$setLoading` methods throw errors
+as the map should not be set at once but instead all have its individual keys set.
+The following methods are map specific:
 
 ---
 
 #### `$delete(key)`
 
-Removes the node for that particular key. `$getAll()` and `$keys()` will no longer include the node.
-
----
-
-#### `$get()`
-
-Returns a mapping from `key` to `$key(key).$get()` for all keys with data.
+Removes the node for that particular key. `$get()` and `$keys()` will no longer include the node.
 
 ---
 

--- a/docs/api/map_methods.md
+++ b/docs/api/map_methods.md
@@ -10,7 +10,7 @@ Removes the node for that particular key. `$getAll()` and `$keys()` will no long
 
 ---
 
-#### `$getAll()`
+#### `$get()`
 
 Returns a mapping from `key` to `$key(key).$get()` for all keys with data.
 

--- a/docs/redux_comparison.md
+++ b/docs/redux_comparison.md
@@ -105,7 +105,7 @@ const getVisibleTodos = (todos, filter) => {
 
 const mapProps = (store) => {
   return {
-    todos: getVisibleTodos(store.todos.$getAll(), store.visibilityFilter.$get()),
+    todos: getVisibleTodos(store.todos.$get(), store.visibilityFilter.$get()),
     onTodoClick: (id) => store.todos.toggle(id)
   }
 }

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -163,7 +163,7 @@ store.userSession.projects.$key('project1').$set({
 store.userSession.projects.$keys() // ['project1']
 
 // Returns a mapping for all accessed keys with data
-store.userSession.projects.$getAll() // {'project1': {summary: <...>, title: 'Nectarine'}}
+store.userSession.projects.$get() // {'project1': {summary: <...>, title: 'Nectarine'}}
 ```
 
 ## Actions

--- a/src/store-tree/index.ls
+++ b/src/store-tree/index.ls
@@ -10,7 +10,7 @@ class StoreTree extends StoreNode
     super ...
     for own key, value of @_children
       @[key] = value
-      value.$on-update @$emit-update
+      value.$on-update @$emit-update.bind(@)
 
     clashes = intersection Object.keys(@_children), Object.keys(actions or {})
     if clashes.length > 0
@@ -64,7 +64,7 @@ class StoreTree extends StoreNode
     | otherwise => throw Error 'calling $set on a tree must be called with an object or null'
 
 
-  $set-error: (err) !~> @$batch-emit-updates ~>
+  $set-error: (err) !-> @$batch-emit-updates ~>
     unless err?
       throw Error "Error setting `#{@$get-path-string!}`: attempting to set error to undefined. Always pass in an error"
 

--- a/src/store-tree/index.ls
+++ b/src/store-tree/index.ls
@@ -10,7 +10,7 @@ class StoreTree extends StoreNode
     super ...
     for own key, value of @_children
       @[key] = value
-      value.$on-update @$emit-update.bind(@)
+      value.$on-update @$emit-update
 
     clashes = intersection Object.keys(@_children), Object.keys(actions or {})
     if clashes.length > 0

--- a/src/store-tree/store-map.ls
+++ b/src/store-tree/store-map.ls
@@ -45,7 +45,7 @@ class StoreMap extends StoreTree
 
   _build-child: (key) ->
     build-store-node path: @$get-path!.concat(key), schema: @_child-schema
-      ..$on-update @$emit-update.bind(@)
+      ..$on-update @$emit-update
 
 
   _build-error-message: (disallowed, suggestion) ->

--- a/src/store-tree/store-map.ls
+++ b/src/store-tree/store-map.ls
@@ -1,56 +1,34 @@
 require! {
   './schema-placeholder': SchemaPlaceholder
   './store-leaf': StoreLeaf
-  './store-node': StoreNode
+  './': StoreTree
   './helpers': {build-store-node}
   'prelude-ls': {Obj: {map}}
+  '../utils': {merge-objects}
 }
 
 
-class StoreMap extends StoreNode
+class StoreMap extends StoreTree
 
-  ({child-schema: @_child-schema}) ->
-    super ...
-    @_mapping = {}
-
-
-  $debug: ->
-    @_mapping |> map (.$debug!)
+  (options) ->
+    {child-schema: @_child-schema} = options
+    super merge-objects(options, children: {})
 
 
   $delete: (key) ->
-    delete @_mapping[key] 
+    delete @_children[key]
 
 
   $from-promise: ->
     throw Error @_build-error-message '$fromPromise()', '$key(k).$fromPromise(v)'
 
 
-  $get-error: ->
-    throw Error @_build-error-message '$getError()', "$getAll('error')"
-
-
-  $get: ->
-    throw Error @_build-error-message '$get()', '$getAll()'
-
-
-  $get-all: ->
-    obj = {}
-    for own key, value of @_mapping
-      try obj[key] = value.$get!
-    obj
-
-
-  $is-loading: ->
-    throw Error @_build-error-message '$isLoading()', "$getAll('loading')"
-
-
   $key: (key) ->
-    @_mapping[key] or= @_build-child key
+    @_children[key] or= @_build-child key
 
 
   $keys: ->
-    Object.keys @_mapping
+    Object.keys @_children
 
 
   $set: ->
@@ -67,7 +45,7 @@ class StoreMap extends StoreNode
 
   _build-child: (key) ->
     build-store-node path: @$get-path!.concat(key), schema: @_child-schema
-      ..$on-update @$emit-update
+      ..$on-update @$emit-update.bind(@)
 
 
   _build-error-message: (disallowed, suggestion) ->

--- a/src/store-tree/store-map.spec.ls
+++ b/src/store-tree/store-map.spec.ls
@@ -26,7 +26,7 @@ describe 'StoreMap' ->
         @map.$delete('1')
         expect(@map.$key('1').$get!).to.eql name: null
 
-      specify 'removes the node from future $getAll calls' ->
+      specify 'removes the node from future $get calls' ->
         @map.$key('1').$set name: 'Alice'
         @map.$delete('1')
         expect(@map.$get!).to.eql {}

--- a/src/store-tree/store-map.spec.ls
+++ b/src/store-tree/store-map.spec.ls
@@ -29,7 +29,7 @@ describe 'StoreMap' ->
       specify 'removes the node from future $getAll calls' ->
         @map.$key('1').$set name: 'Alice'
         @map.$delete('1')
-        expect(@map.$get-all!).to.eql {}
+        expect(@map.$get!).to.eql {}
 
       specify 'removes the key from future $keys calls' ->
         @map.$key('1').$set name: 'Alice'
@@ -58,43 +58,60 @@ describe 'StoreMap' ->
 
     describe '$get' ->
 
-      specify 'throws an error' ->
-        expect(~>
-          @map.$get!
-        ).to.throw 'Error at `path.to.map`: $get() can not be used on a map. Use $getAll()'
+      specify 'returns a mapping of all the keys' ->
+        @map.$key('1').$set name: 'Alice'
+        @map.$key('2').$set name: 'Bob'
+        expect(@map.$get!).to.eql do
+          1: {name: 'Alice'}
+          2: {name: 'Bob'}
 
-
-    describe '$get-all' ->
-
-      before-each ->
+      specify 'throws an error when attempting to access data with error' ->
         @map.$key('1').$set name: 'Alice'
         @map.$key('2').$set-error new Error 'error1'
-        @map.$key('3').$set-loading!
-        @map.$key('4').$set name: 'Bob'
-        @map.$key('5').$set-error new Error 'error2'
-        @map.$key('6').$set-loading!
+        expect(~> @map.$get!).to.throw 'Error getting `path.to.map.2.name`: has error "error1"'
 
-      specify 'returns a mapping of all the keys with data' ->
-        expect(@map.$get-all!).to.eql do
-          1: {name: 'Alice'}
-          4: {name: 'Bob'}
+      specify 'throws an error when attempting to access loading data' ->
+        @map.$key('1').$set name: 'Alice'
+        @map.$key('2').$set-loading!
+        expect(~> @map.$get!).to.throw 'Error getting `path.to.map.2.name`: is loading'
 
 
     describe '$get-error' ->
 
-      specify 'throws an error' ->
-        expect(~>
-          @map.$get-error!
-        ).to.throw "Error at `path.to.map`: $getError() can not be used on a map. Use $getAll('error')"
+      specify 'returns null for an empty map' ->
+        expect(@map.$get-error!).to.eql null
 
+      specify 'returns null if all keys have data' ->
+        @map.$key('1').$set name: 'Alice'
+        @map.$key('2').$set name: 'Bob'
+        expect(@map.$get!).to.eql do
+          1: {name: 'Alice'}
+          2: {name: 'Bob'}
+
+      specify 'returns the first error if any keys have errors' ->
+        @map.$key('1').$set name: 'Alice'
+        @map.$key('2').$set-error new Error 'error1'
+        expect(@map.$get-error!).to.eql new Error 'error1'
+
+      specify 'returns the first error if multiple keys have errors' ->
+        @map.$key('1').$set-error new Error 'error1'
+        @map.$key('2').$set-error new Error 'error2'
+        expect(@map.$get-error!).to.eql new Error 'error2'
 
     describe '$is-loading' ->
 
-      specify 'throws an error' ->
-        expect(~>
-          @map.$is-loading!
-        ).to.throw "Error at `path.to.map`: $isLoading() can not be used on a map. Use $getAll('loading')"
+      specify 'returns false for an empty map' ->
+        expect(@map.$is-loading!).to.eql false
 
+      specify 'returns false if all keys have data' ->
+        @map.$key('1').$set name: 'Alice'
+        @map.$key('2').$set name: 'Bob'
+        expect(@map.$is-loading!).to.eql false
+
+      specify 'returns true if any keys have errors' ->
+        @map.$key('1').$set name: 'Alice'
+        @map.$key('2').$set-loading!
+        expect(@map.$is-loading!).to.eql true
 
     describe '$key', ->
 

--- a/src/store-tree/store-node.ls
+++ b/src/store-tree/store-node.ls
@@ -25,7 +25,7 @@ class StoreNode
     @$emit-update {path: @$get-path!, updates}
 
 
-  $emit-update: (arg) ~>
+  $emit-update: (arg) ->
     if @_should-queue-updates
       @_queued-updates.push arg
     else

--- a/src/store-tree/store-node.ls
+++ b/src/store-tree/store-node.ls
@@ -25,7 +25,7 @@ class StoreNode
     @$emit-update {path: @$get-path!, updates}
 
 
-  $emit-update: (arg) ->
+  $emit-update: (arg) ~>
     if @_should-queue-updates
       @_queued-updates.push arg
     else


### PR DESCRIPTION
Make `map` inherit from store tree. It now just adds the map specific methods and overrides the setter methods to error.

resolves #63 